### PR TITLE
fix: Add await to Metrics update call in producer_endpoint

### DIFF
--- a/backend/src/api/producer_endpoint.py
+++ b/backend/src/api/producer_endpoint.py
@@ -31,7 +31,7 @@ async def send_message(topic):
     elapsed_time = end_time - start_time
 
     # Update the metrics for the send operation with the elapsed time
-    
+    await g.metrics.update_send_metrics(elapsed_time)
     # Return a JSON response with the status and message details
     return jsonify({"status": "Message sent", "topic": topic, "message": message})
 


### PR DESCRIPTION
Eliminate the warning caused by missing await required to update metrics.